### PR TITLE
Correctly handle situation when choice cmd couldn't be found

### DIFF
--- a/Backup-TA.bat
+++ b/Backup-TA.bat
@@ -28,7 +28,11 @@ if "!errorlevel!" == "1" (
 				if "!errorlevel!" == "1" (
 					set CHOICE=tools\choice64.exe
 					set CHOICE_TEXT_PARAM=/M
-				) 
+				) else (
+					echo Choice command could not be found, terminating
+					pause
+					goto :eof
+				)
 			)
 		)
 	)


### PR DESCRIPTION
I have all the choice binaries not working on my XP SP3 machine. *32 says "Cannot run program" and *32_alt and *64 both say "Not a Win32 program". But the script goes on doing useless and potentially harmful stuff. I suggest adding the proper handling as well as providing another binary. I found [this one](http://www.dynawell.com/download/ResKit/Microsoft/WinNT/choice.zip) working for me (placed it as CHOICE32.EXE according to cmd line syntax it required) but there's also binary from Win98(ftp://ftp.microsoft.com/Services/TechNet/samples/PS/Win98/Reskit/SCRPTING/CHOICE.EXE) that is likely more preferrable (the source is MS) and it worked on my PC too.
This change will probably fix #7
