### PR TITLE
Update compatible-devices.txt - Added Z2 Tablet SGP528 LTE model as V…

### DIFF
--- a/compatible-devices.txt
+++ b/compatible-devices.txt
@@ -33,6 +33,7 @@ Sony Xperia Tipo
 Sony Xperia J
 Sony Xperia E
 Sony Xperia Tablet Z
+Sony Xperia Tablet Z2 SGP528 (LTE,WiFi etc.. NOT tested on WiFi only model) Codename:Castor Board:Shinano
 
 Most likely: 
 -----------------------


### PR DESCRIPTION
…erified to a database

Added Z2 Tablet SGP528 LTE model as Verified to a database

Sony Xperia Tablet Z2 SGP528 (LTE,WiFi etc.. NOT tested on WiFi only model) Codename:Castor Board:Shinano